### PR TITLE
Add adult-only background and autoplay options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # PlayerKids
-Projeto player infantil supervisionado
+Projeto player infantil supervisionado.
+
+## Recursos
+
+- Reprodução em segundo plano para perfis adultos.
+- Opção de reprodução automática da lista de vídeos para perfis adultos.

--- a/index.html
+++ b/index.html
@@ -131,7 +131,25 @@
                 </div>
                 <div id="userInfo" class="text-sm text-gray-500 mb-4 text-center">
                     Autenticado como: <span id="userEmailDisplay"></span>
+                    <div class="mt-2">
+                        <label for="profileSelect" class="mr-2">Perfil:</label>
+                        <select id="profileSelect" class="bg-gray-700 text-gray-200 rounded">
+                            <option value="kid">Infantil</option>
+                            <option value="adult">Adulto</option>
+                        </select>
+                    </div>
+                    <div id="adultOptions" class="mt-2 hidden">
+                        <label class="inline-flex items-center mr-4">
+                            <input type="checkbox" id="autoplayToggle" class="form-checkbox h-4 w-4 text-blue-500">
+                            <span class="ml-2">Reprodução Automática</span>
+                        </label>
+                        <label class="inline-flex items-center">
+                            <input type="checkbox" id="backgroundToggle" class="form-checkbox h-4 w-4 text-blue-500">
+                            <span class="ml-2">Segundo Plano</span>
+                        </label>
+                    </div>
                 </div>
+                <button id="backgroundPlayerButton" class="fixed bottom-4 right-4 px-4 py-2 bg-blue-600 text-white rounded-full shadow-lg hidden">Reabrir Player</button>
                 <div id="curatedFeedContainer" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
                     <!-- User's curated videos will be injected here by JavaScript -->
                 </div>
@@ -151,6 +169,9 @@
         let userId = null;
         let appId = typeof __app_id !== 'undefined' ? __app_id : 'default-app-id';
         let player;
+        let isAdult = false;
+        let autoplayEnabled = false;
+        let backgroundPlaybackEnabled = false;
         
         // A sua chave da API do YouTube
         const YOUTUBE_API_KEY = "AIzaSyAmNMrkBFKqaUV-aOa1XBtJ5sEKBjDJwWA";
@@ -164,18 +185,21 @@
         function onPlayerStateChange(event) {
             // Verifica se o vídeo terminou
             if (event.data === YT.PlayerState.ENDED) {
-                const currentVideoId = event.target.getVideoData().video_id;
-                const currentIndex = curatedFeed.findIndex(v => v.id === currentVideoId);
-                const nextIndex = currentIndex + 1;
-
-                // Se houver um próximo vídeo no feed, reproduza-o
-                if (nextIndex < curatedFeed.length) {
-                    const nextVideoId = curatedFeed[nextIndex].id;
-                    playVideo(nextVideoId);
-                } else {
-                    // Se for o último vídeo, feche o modal
-                    closeVideoModal();
+                if (isAdult && autoplayEnabled) {
+                    const currentVideoId = event.target.getVideoData().video_id;
+                    const currentIndex = curatedFeed.findIndex(v => v.id === currentVideoId);
+                    const nextIndex = currentIndex + 1;
+                    if (nextIndex < curatedFeed.length) {
+                        const nextVideoId = curatedFeed[nextIndex].id;
+                        if (videoModal.classList.contains('hidden')) {
+                            player.loadVideoById(nextVideoId);
+                        } else {
+                            playVideo(nextVideoId);
+                        }
+                        return;
+                    }
                 }
+                closeVideoModal(true);
             }
         }
         
@@ -188,6 +212,12 @@
             const loginButton = document.getElementById('loginButton');
             const signupButton = document.getElementById('signupButton');
             const userEmailDisplay = document.getElementById('userEmailDisplay');
+            const profileSelect = document.getElementById('profileSelect');
+            const adultOptions = document.getElementById('adultOptions');
+            const autoplayToggle = document.getElementById('autoplayToggle');
+            const backgroundToggle = document.getElementById('backgroundToggle');
+            const backgroundPlayerButton = document.getElementById('backgroundPlayerButton');
+
 
             const searchInput = document.getElementById('searchInput');
             const searchButton = document.getElementById('searchButton');
@@ -200,6 +230,40 @@
             const suggestTopicsButton = document.getElementById('suggestTopicsButton');
             const videoModal = document.getElementById('videoModal');
             const videoPlayerContainer = document.getElementById('videoPlayerContainer');
+
+            profileSelect.addEventListener('change', () => {
+                isAdult = profileSelect.value === 'adult';
+                adultOptions.classList.toggle('hidden', !isAdult);
+                if (!isAdult) {
+                    autoplayEnabled = false;
+                    backgroundPlaybackEnabled = false;
+                    autoplayToggle.checked = false;
+                    backgroundToggle.checked = false;
+                    if (player) {
+                        closeVideoModal(true);
+                    }
+                }
+            });
+
+            autoplayToggle.addEventListener('change', () => {
+                autoplayEnabled = autoplayToggle.checked;
+            });
+
+            backgroundToggle.addEventListener('change', () => {
+                backgroundPlaybackEnabled = backgroundToggle.checked;
+                if (!backgroundPlaybackEnabled) {
+                    backgroundPlayerButton.classList.add('hidden');
+                    if (player && videoModal.classList.contains('hidden')) {
+                        closeVideoModal(true);
+                    }
+                }
+            });
+
+            backgroundPlayerButton.addEventListener('click', () => {
+                videoModal.classList.remove('hidden');
+                videoModal.classList.add('flex');
+                backgroundPlayerButton.classList.add('hidden');
+            });
 
             // --- Firebase Setup ---
             const firebaseConfig = {
@@ -243,6 +307,13 @@
                 if (user) {
                     userId = user.uid;
                     userEmailDisplay.textContent = user.email;
+                    profileSelect.value = 'kid';
+                    isAdult = false;
+                    adultOptions.classList.add('hidden');
+                    autoplayEnabled = false;
+                    backgroundPlaybackEnabled = false;
+                    autoplayToggle.checked = false;
+                    backgroundToggle.checked = false;
                     // Esconde a tela de autenticação e mostra o app principal
                     authScreen.classList.add('hidden');
                     mainApp.classList.remove('hidden');
@@ -296,15 +367,20 @@
                 appModal.style.display = 'none';
             };
 
-            window.closeVideoModal = () => {
+            window.closeVideoModal = (forceStop = false) => {
                 if (document.fullscreenElement) {
                     document.exitFullscreen();
                 }
                 if (player) {
-                    player.destroy();
-                    player = null;
+                    if (forceStop || !backgroundPlaybackEnabled || !isAdult) {
+                        player.destroy();
+                        player = null;
+                        videoPlayerContainer.innerHTML = '';
+                        backgroundPlayerButton.classList.add('hidden');
+                    } else {
+                        backgroundPlayerButton.classList.remove('hidden');
+                    }
                 }
-                videoPlayerContainer.innerHTML = '';
                 videoModal.classList.remove('flex');
                 videoModal.classList.add('hidden');
             };
@@ -439,6 +515,7 @@
             };
 
             window.playVideo = (videoId) => {
+                backgroundPlayerButton.classList.add('hidden');
                 videoModal.classList.remove('hidden');
                 videoModal.classList.add('flex');
                 if (!player) {


### PR DESCRIPTION
## Summary
- Allow account profile selection with adult-only controls for autoplay and background playback
- Let adults toggle automatic video advancement and keep audio playing when the modal is closed
- Document new background and autoplay features in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b45e85cbc08330aa11d38d57a89bf8